### PR TITLE
add imagemin compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ gulp.task('minify-images', minifyImagesCli);
 
 ## История изменений
 
+###1.0.1
+
+* Установили жесткие зависимости на gulp-imagemin и imagemin
+
 ###1.0.0
 
 * первичный релиз

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hh.ru/gulp-minify-images",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "library for cli images minify",
   "main": "index.js",
   "repository": {
@@ -16,10 +16,8 @@
     "url": "https://github.com/hhru/gulp-minify-images/issues"
   },
   "homepage": "https://github.com/hhru/gulp-minify-images",
-  "peerDependencies": {
-    "gulp": "^3.9.0"
-  },
   "devDependencies": {
+    "gulp": "^3.9.0",
     "yargs": "~3.15.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,9 +16,14 @@
     "url": "https://github.com/hhru/gulp-minify-images/issues"
   },
   "homepage": "https://github.com/hhru/gulp-minify-images",
+  "peerDependencies": {
+    "gulp": "^3.9.0"
+  },
   "devDependencies": {
-    "gulp": "^3.9.0",
-    "gulp-imagemin": "~3.1.1",
     "yargs": "~3.15.0"
+  },
+  "dependencies": {
+    "gulp-imagemin": "~3.1.1",
+    "imagemin": "~5.2.2"
   }
 }


### PR DESCRIPTION
imagemin выпустил новую версию, а она с бажком + нам нужно указывать явные зависимости, а не надеяться, что в нужном нам проекте есть нужный нам компонент